### PR TITLE
Cleanup unused ohm generate script

### DIFF
--- a/cdk/cdk.context.json
+++ b/cdk/cdk.context.json
@@ -1,0 +1,5 @@
+{
+  "acknowledged-issue-numbers": [
+    34892
+  ]
+}

--- a/lambda-src/package.json
+++ b/lambda-src/package.json
@@ -2,8 +2,7 @@
   "scripts": {
     "lint": "../../node_modules/.bin/eslint .",
     "fix": "eslint . --fix",
-    "test": "jest",
-    "generate": "ohm generateBundles --withTypes 'ts-src/*.ohm'"
+    "test": "jest"
   },
   "devDependencies": {
     "@aws-sdk/client-lambda": "^3.965.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -200,7 +200,6 @@
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
       "version": "1.4.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -209,7 +208,6 @@
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
       "version": "7.7.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -4797,13 +4795,11 @@
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
       "version": "1.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
       "version": "8.17.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4819,7 +4815,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4828,7 +4823,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4843,7 +4837,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/astral-regex": {
       "version": "2.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4852,13 +4845,11 @@
     },
     "node_modules/aws-cdk-lib/node_modules/balanced-match": {
       "version": "1.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
       "version": "1.1.12",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4868,7 +4859,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/case": {
       "version": "1.6.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "(MIT OR GPL-3.0-or-later)",
       "engines": {
@@ -4877,7 +4867,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/color-convert": {
       "version": "2.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4889,31 +4878,26 @@
     },
     "node_modules/aws-cdk-lib/node_modules/color-name": {
       "version": "1.1.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/concat-map": {
       "version": "0.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
       "version": "3.1.0",
-      "extraneous": true,
       "funding": [
         {
           "type": "github",
@@ -4929,7 +4913,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
       "version": "11.3.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4943,13 +4926,11 @@
     },
     "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
       "version": "4.2.11",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
       "version": "5.3.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4958,7 +4939,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4967,13 +4947,11 @@
     },
     "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
       "version": "6.2.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4985,7 +4963,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/jsonschema": {
       "version": "1.5.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4994,13 +4971,11 @@
     },
     "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
       "version": "4.4.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/mime-db": {
       "version": "1.52.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5009,7 +4984,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/mime-types": {
       "version": "2.1.35",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5021,7 +4995,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
       "version": "3.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5033,7 +5006,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
       "version": "2.3.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5042,7 +5014,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/require-from-string": {
       "version": "2.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5051,7 +5022,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
       "version": "7.7.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -5063,7 +5033,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
       "version": "4.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5080,7 +5049,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/string-width": {
       "version": "4.2.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5094,7 +5062,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5106,7 +5073,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/table": {
       "version": "6.9.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -5122,7 +5088,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
       "version": "2.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5131,7 +5096,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
       "version": "1.10.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {


### PR DESCRIPTION
## Description
This PR removes the unused `generate` script from `lambda-src/package.json` that was referencing `ohm`. As checked, there are no `.ohm` files in the project and `ohm` is not a dependency.

### Changes:
- Removed `"generate": "ohm generateBundles --withTypes 'ts-src/*.ohm'"` from `lambda-src/package.json`.
- Updated lockfiles accordingly.